### PR TITLE
feat: optionally set query & stream url manually

### DIFF
--- a/js/src/client/MicrogenClient.ts
+++ b/js/src/client/MicrogenClient.ts
@@ -27,8 +27,19 @@ export default class MicrogenClient {
       protocol = 'https';
     }
 
-    this.queryUrl = `${protocol}://database-query.${host}/api/v1/${options.apiKey}`;
-    this.realtimeUrl = `${protocol}://database-stream.${host}`;
+    let queryUrl = `${protocol}://database-query.${host}/api/v1/`
+    let streamUrl = `${protocol}://database-stream.${host}`
+
+    if (options.queryUrl) {
+      queryUrl = options.queryUrl
+    }
+
+    if (options.streamUrl) {
+      streamUrl = options.streamUrl
+    }
+
+    this.queryUrl = `${queryUrl}${options.apiKey}`;
+    this.realtimeUrl = streamUrl;
     this.apiKey = options.apiKey;
     this.headers = {};
     this.auth = this._initAuth();

--- a/js/src/client/lib/types.ts
+++ b/js/src/client/lib/types.ts
@@ -11,4 +11,12 @@ export type MicrogenClientOptions = {
    * secure protocol
    */
   isSecure?: boolean;
+  /**
+   * Dedicated Microgen Query URL
+   */
+  queryUrl?: string;
+  /**
+   * Dedicated Microgen Stream URL
+   */
+  streamUrl?: string;
 };


### PR DESCRIPTION
I have an dedicated microgen on my environment, i want to set the query & stream url by my own, without any prefix